### PR TITLE
Add help window

### DIFF
--- a/react/src/Components/ActivityComponents/BinaryVerification.tsx
+++ b/react/src/Components/ActivityComponents/BinaryVerification.tsx
@@ -4,6 +4,7 @@ import {
     calculateImageDimensions,
 } from "../../Utils/CanvasCalcs";
 import { ActivityAction, ActivityInstruction, DoneButtonComponent, SoftCropCanvas } from "../UIElements";
+import HelpButtonComponent from "../UIElements/HelpButtonComponent";
 
 interface IBinaryVerificationState {
     rect1: IRect;
@@ -159,6 +160,7 @@ class BinaryVerification extends Component<IBinaryVerificationProps, IBinaryVeri
         }
 
         const doneButtonHeight = 70;
+        const category = <b>{this.props.activity.activity_config.category.toLowerCase()}</b>
         return <div
             style={{ height: "100%", width: "100%" }}
             ref={(divElement) => this.view = divElement}
@@ -167,9 +169,10 @@ class BinaryVerification extends Component<IBinaryVerificationProps, IBinaryVeri
                 ref={(divElement: any) => this.activityInstruction = divElement}
                 onResize={this.onInstructionResize}>
                 <div className="question runSlideIn">
-                    Please select the <b>better</b> box around the
-                        <b> {this.props.activity.activity_config.category.toLowerCase()}</b>
-                    <div className="help"><span style={{verticalAlign: "sub"}}>?</span></div>
+                    Please select the <b>better</b> box around the {category}
+                    <HelpButtonComponent>
+                        There are two boxes drawn around the {category}. Tap the box which more tightly contains the {category} without cutting it off.
+                    </HelpButtonComponent>/>
                 </div>
             </ActivityInstruction>
             <div style={{ height: this.activityBodyHeight, width: this.activityBodyWidth }}

--- a/react/src/Components/ActivityComponents/BoundingBoxTap.tsx
+++ b/react/src/Components/ActivityComponents/BoundingBoxTap.tsx
@@ -10,7 +10,7 @@ import {
     touchToImageCoords,
     windowTouchToCanvasCoords,
 } from "../../Utils";
-import { ActivityAction, ActivityInstruction, DoneButtonComponent } from "../UIElements";
+import { ActivityAction, ActivityInstruction, DoneButtonComponent, HelpButtonComponent } from "../UIElements";
 
 interface IBoundingBoxTapState {
     windowWidth: number;
@@ -376,18 +376,27 @@ class BoundingBoxTap extends Component<IBoundingBoxTapProps, IBoundingBoxTapStat
 
     public render() {
         this.updateActivityBodyDims();
+        const category = <b>{this.props.activity.config.category.toLowerCase()}</b>
         const question = this.state.currentStage < this.numberOfStages ?
             <div className="question runSlideIn">
                 Please tap the
                 <div className={"bolded " + this.state.stepClassName}>
                 &nbsp;{INSTRUCTION[this.state.currentStage]}
                 </div> side
-                of the <b>{this.props.activity.config.category.toLowerCase()}</b>
-                <div className="help"><span style={{ verticalAlign: "sub" }}>?</span></div>
+                of the {category}
+                <HelpButtonComponent>
+                    Tap the sides of the {category} as accurately as possible.
+
+                    Once you have tapped all four sides of the {category}, you can modify your selection.
+                </HelpButtonComponent>
             </div> :
             <div className={"question " + this.state.stepClassName}>
                 Please verify that all 4 borders touch, and fix them if they don't
-                <div className="help"><span style={{ verticalAlign: "sub" }}>?</span></div>
+                <HelpButtonComponent>
+                    If you are unhappy with the sides you selected, you can tap and drag to readjust them.
+
+                    Try to form a tight box around the {category}.
+                </HelpButtonComponent>
             </div>;
 
         const doneButtonHeight = 70;

--- a/react/src/Components/UIElements/HelpButtonComponent.tsx
+++ b/react/src/Components/UIElements/HelpButtonComponent.tsx
@@ -1,0 +1,57 @@
+import React, { Component } from "react";
+
+interface IHelpButtonProps { }
+
+interface IHelpButtonState {
+    visible: boolean;
+}
+
+class HelpButtonComponent extends Component<IHelpButtonProps, IHelpButtonState> {
+    constructor(props: IHelpButtonProps) {
+        super(props);
+        this.state = {
+            visible: false
+        }
+
+        // Bindings
+        this.helpButton = this.helpButton.bind(this);
+        this.closeButton = this.closeButton.bind(this);
+    }
+
+    public helpButton() {
+        this.setState((state, props) => ({
+            visible: !state.visible
+        }))
+    }
+
+    public closeButton() {
+        this.setState({
+            visible: false
+        })
+    }
+
+    public render() {
+        let helpWindow = null
+        if (this.state.visible) {
+            helpWindow = <div className="both-center helpWindow">
+                <div style={{overflow: "hidden"}}>
+                    <span className="closeButton" onClick={this.closeButton}>x</span>
+                </div>
+                {this.props.children}
+            </div>;
+        }
+
+        return (
+            <span>
+                <div className="help">
+                    <span className="helpButton" onClick={this.helpButton}>
+                        ?
+                    </span>
+                </div>
+                {helpWindow}
+            </span>
+        );
+    }
+}
+
+export default HelpButtonComponent;

--- a/react/src/Components/UIElements/index.js
+++ b/react/src/Components/UIElements/index.js
@@ -6,6 +6,7 @@ export { default as ProgressBarComponent } from "./ProgressBarComponent";
 export { default as FooterComponent } from "./FooterComponent";
 export { default as InputTurkID } from "./InputTurkID";
 export { default as DoneButtonComponent } from "./DoneButtonComponent";
+export { default as HelpButtonComponent } from "./HelpButtonComponent"
 export { default as SoftCropCanvas } from "./SoftCropCanvas";
 export { default as ActivityAction } from "./ActivityAction";
 export { default as ActivityInstruction } from "./ActivityInstruction";

--- a/react/src/index.css
+++ b/react/src/index.css
@@ -614,9 +614,28 @@ a.landing {
   color: white;
 }
 
+.helpButton {
+    vertical-align: sub;
+    user-select: none;
+}
+
 .help:hover {
   cursor: pointer;
   opacity: 0.8;
+}
+
+.helpWindow {
+    height: 80%;
+    width: 80%;
+    background-color: white;
+    border-radius: 10px;
+}
+
+.closeButton {
+    float: right;
+    right: 0;
+    padding-right: 10px;
+    user-select: none;
 }
 
 @keyframes goodjobzoom


### PR DESCRIPTION
This adds functionality for the help button. Clicking the "?" in a task prompt will toggle a help window with a description about how to complete the task. The window itself also has an X which can be clicked to close the window (would we also want to interpret a click anywhere outside the window as a close, i.e. click out of focus?).

I'll leave the design/styling to George. 

![image](https://user-images.githubusercontent.com/6363768/72758888-128a0f80-3ba2-11ea-87bb-e7ea3a0dc741.png)

![image](https://user-images.githubusercontent.com/6363768/72758865-fdad7c00-3ba1-11ea-883c-b5d92c85c40c.png)
