### PR TITLE
rails: allow toggling activities enabled/disabled

### DIFF
--- a/rails/app/controllers/v1/activities_controller.rb
+++ b/rails/app/controllers/v1/activities_controller.rb
@@ -10,6 +10,18 @@ class V1::ActivitiesController < ApplicationController
 
   # GET /activities/available
   def available
-    json_response(false)
+    json_response(Rails.cache.read('available'))
+  end
+
+  # GET /activities/enable
+  def enable
+    Rails.cache.write('available', true)
+    json_response(Rails.cache.read('available'))
+  end
+
+  # GET /activities/disable
+  def disable
+    Rails.cache.write('available', false)
+    json_response(Rails.cache.read('available'))
   end
 end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
 
   scope module: :v1, defaults: { format: :json }, constraints: ApiConstraints.new(version: 1, default: true) do
     resource :activities, only: %i[show] do
-      get 'available'
+      get 'available', 'enable', 'disable'
     end
     resources :samples, only: %i[create]
     resources :projects, only: %i[index show update create delete] do


### PR DESCRIPTION
Using the rails cache here as a quick and dirty way to test our endpoint/get the game past review.

Obviously should not use the rails cache to store state but hey we gotta _move fast_

how to use:
visit 
https://tagbull-prod.appspot.com/activities/enable

https://tagbull-prod.appspot.com/activities/disable

and 

https://tagbull-prod.appspot.com/activities/available


When you're done, pls leave in the disabled state thx