### PR TITLE
rails+react: fix various full stack errors

### DIFF
--- a/rails/app/models/activity.rb
+++ b/rails/app/models/activity.rb
@@ -36,7 +36,11 @@ class Activity
 
       self.config = {
         media_url: Medium.find(task.media_id).url,
-        category: bb.category
+        category: bb.category,
+        target_point: {
+          x: bb.x,
+          y: bb.y
+        }
       }
     when LocatorTask
       locator = task.specific
@@ -72,7 +76,10 @@ class Activity
 
   def tasks_filter
     <<-SQL
-      (basic_task_states.state = 'start' OR basic_task_states.state = 'sampling')
+      (tasks.actable_type = 'BoundingBoxTask'
+        OR tasks.actable_type = 'LocatorTask'
+        OR tasks.actable_type = 'DiscreteAttributeTask')
+      AND (basic_task_states.state = 'start' OR basic_task_states.state = 'sampling')
       AND (tasks.pending_timestamp IS NULL OR NOW() > tasks.pending_timestamp + (1 * INTERVAL '1 minute') )
       AND NOT EXISTS(SELECT 1 FROM samples WHERE samples.actor_id = ? AND samples.task_id = tasks.id)
     SQL

--- a/rails/app/models/generators/locator_generator.rb
+++ b/rails/app/models/generators/locator_generator.rb
@@ -25,28 +25,25 @@ class LocatorGenerator
 
   def self.compare_points_lists(sample1, sample2, _threshold)
     # TODO: add complexity to points list comparison
-    JSON.parse(sample1.points).length == JSON.parse(sample2.points).length
+    sample1.points.length == sample2.points.length
   end
 
   def self.generate_points(task, samples)
     points = merge_points_lists(samples)
     LocatorSample.create!({
-      points: points.to_json
+      points: points
     }.merge(TagGenerator.generated_sample_params(task)))
   end
 
   def self.merge_points_lists(samples)
-    points1 = JSON.parse(samples[0].points)
-    points1 = sort_by_x_then_y(points1)
-
-    points2 = JSON.parse(samples[1].points)
-    points2 = sort_by_x_then_y(points2)
+    points1 = sort_by_x_then_y(samples[0].points)
+    points2 = sort_by_x_then_y(samples[1].points)
 
     average_points_lists(points1, points2)
   end
 
   def self.sort_by_x_then_y(points)
-    points.sort_by { |e| [e['x'], e['y']] }
+    points.sort_by { |e| [e['x'].to_f, e['y'].to_f] }
   end
 
   def self.average_points_lists(points1, points2)

--- a/rails/app/models/samples/locator_sample.rb
+++ b/rails/app/models/samples/locator_sample.rb
@@ -23,18 +23,19 @@ class LocatorSample < ApplicationRecord
     end
 
     def check_points_array(record)
-      points = JSON.parse(record.points)
-      unless points.is_a?(Array)
+      unless record.points.is_a?(Array)
         record.errors[:points] << 'Points need to be an array'
         return false
       end
 
-      points
+      record.points
     end
 
     def check_points_in_range(record, points)
       points.each do |point|
-        unless point['x'] >= 0 && point['x'] <= 1 && point['y'] >= 0 && point['y'] <= 1
+        x = point['x'].to_f
+        y = point['y'].to_f
+        unless x >= 0 && x <= 1 && y >= 0 && y <= 1
           record.errors[:points] << 'Point coordinates need to be between 0 and 1'
         end
       end

--- a/rails/app/models/tasks/dichotomy_task.rb
+++ b/rails/app/models/tasks/dichotomy_task.rb
@@ -22,11 +22,9 @@ class DichotomyTask < ApplicationRecord
   end
 
   def locator_completed(locator_tag)
-    points = JSON.parse(locator_tag.points)
+    return if locator_tag.points.length >= 5
 
-    return if points.length >= 5
-
-    create_bounding_box_tasks(points)
+    create_bounding_box_tasks(locator_tag.points)
   end
 
   def bounding_box_completed(bounding_box_tag)
@@ -55,8 +53,8 @@ class DichotomyTask < ApplicationRecord
         project_id: project_id,
         media_id: media_id,
         category: parent_category,
-        x: point['x'],
-        y: point['y']
+        x: point['x'].to_f,
+        y: point['y'].to_f
       )
     end
   end
@@ -91,8 +89,7 @@ class DichotomyTask < ApplicationRecord
     locator_tag = LocatorSample.find(parent_id: acting_as.id)
     return false unless locator_tag
 
-    points = JSON.parse(locator_tag.points)
-    bounding_box_and_metadata_finished(points.length)
+    bounding_box_and_metadata_finished(locator_tag.points.length)
   end
 
   def bounding_box_and_metadata_finished(target_count)

--- a/rails/app/models/utils/attr_utils.rb
+++ b/rails/app/models/utils/attr_utils.rb
@@ -11,10 +11,10 @@ class AttrUtils
   end
 
   def self.average_hash(attr, item1, item2)
-    (item1[attr] + item2[attr]) / 2
+    (item1[attr].to_f + item2[attr].to_f) / 2
   end
 
   def self.abs_diff_hash(attr, item1, item2)
-    (item1[attr] - item2[attr]).abs
+    (item1[attr].to_f - item2[attr].to_f).abs
   end
 end

--- a/rails/test/controllers/samples_controller_test.rb
+++ b/rails/test/controllers/samples_controller_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class SamplesControllerTest < ActionDispatch::IntegrationTest
   test 'should create bounding box sample' do
-    p = Project.create!
+    p = Project.create!(name: 'test')
     t = BoundingBoxTask.create!(project: p)
     V1::SamplesController.any_instance.stubs(:maybe_generate_tag).returns(false)
 
@@ -26,7 +26,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create locator sample' do
-    p = Project.create!
+    p = Project.create!(name: 'test')
     t = LocatorTask.create!(project: p)
     V1::SamplesController.any_instance.stubs(:maybe_generate_tag).returns(false)
 
@@ -38,14 +38,14 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
              actor_sig: '123',
              time_elapsed: 2000,
              data: {
-               points: [{ x: 0.1, y: 0.2 }].to_json
+               points: [{ x: 0.1, y: 0.2 }]
              }
            }
     end
   end
 
   test 'should create discrete attr sample' do
-    p = Project.create!
+    p = Project.create!(name: 'test')
     t = DiscreteAttributeTask.create!(project: p)
     V1::SamplesController.any_instance.stubs(:maybe_generate_tag).returns(false)
 

--- a/rails/test/models/locator_generator_test.rb
+++ b/rails/test/models/locator_generator_test.rb
@@ -5,24 +5,24 @@ require 'test_helper'
 class LocatorGeneratorTest < ActiveSupport::TestCase
   test 'compare points lists' do
     threshold = 0.03
-    s1 = LocatorSample.new(points: [{ x: 0.1, y: 0.2 }, { x: 0.3, y: 0.4 }].to_json)
-    s2 = LocatorSample.new(points: [{ x: 0.5, y: 0.6 }].to_json)
+    s1 = LocatorSample.new(points: [{ x: 0.1, y: 0.2 }, { x: 0.3, y: 0.4 }])
+    s2 = LocatorSample.new(points: [{ x: 0.5, y: 0.6 }])
 
     assert LocatorGenerator.compare_points_lists(s1, s1, threshold)
     assert_not LocatorGenerator.compare_points_lists(s1, s2, threshold)
   end
 
   test 'average points lists' do
-    s1 = LocatorSample.new(points: [{ x: 0.1, y: 0.2 }, { x: 0.3, y: 0.4 }].to_json)
-    s2 = LocatorSample.new(points: [{ x: 0.5, y: 0.6 }, { x: 0.5, y: 0.6 }].to_json)
+    s1 = LocatorSample.new(points: [{ x: 0.1, y: 0.2 }, { x: 0.3, y: 0.4 }])
+    s2 = LocatorSample.new(points: [{ x: 0.5, y: 0.6 }, { x: 0.5, y: 0.6 }])
 
-    avg = LocatorGenerator.average_points_lists(JSON.parse(s1.points), JSON.parse(s2.points))
+    avg = LocatorGenerator.average_points_lists(s1.points, s2.points)
     assert avg == [{ x: 0.3, y: 0.4 }, { x: 0.4, y: 0.5 }]
   end
 
   test 'merge points lists' do
-    s1 = LocatorSample.new(points: [{ x: 0.3, y: 0.4 }, { x: 0.1, y: 0.2 }].to_json)
-    s2 = LocatorSample.new(points: [{ x: 0.5, y: 0.6 }, { x: 0.1, y: 0.2 }].to_json)
+    s1 = LocatorSample.new(points: [{ x: 0.3, y: 0.4 }, { x: 0.1, y: 0.2 }])
+    s2 = LocatorSample.new(points: [{ x: 0.5, y: 0.6 }, { x: 0.1, y: 0.2 }])
 
     res = LocatorGenerator.merge_points_lists([s1, s2])
     assert res == [{ x: 0.1, y: 0.2 }, { x: 0.4, y: 0.5 }]

--- a/rails/test/models/locator_sample_test.rb
+++ b/rails/test/models/locator_sample_test.rb
@@ -11,14 +11,14 @@ class LocatorSampleTest < ActiveSupport::TestCase
 
   test 'should not save locator sample with bad points' do
     sample = LocatorSample.new
-    sample.points = [{ x: 1.5, y: 0.2 }].to_json
+    sample.points = [{ x: 1.5, y: 0.2 }]
     assert_not sample.save
     assert_not sample.errors[:points].empty?
   end
 
   test 'should save locator sample with good points' do
     sample = LocatorSample.new
-    sample.points = [{ x: 0.5, y: 0.2 }, { x: 0.3, y: 0.1 }].to_json
+    sample.points = [{ x: 0.5, y: 0.2 }, { x: 0.3, y: 0.1 }]
     sample.save
     assert sample.errors[:points].empty?
   end

--- a/react/src/Components/ActivityComponents/Locator.tsx
+++ b/react/src/Components/ActivityComponents/Locator.tsx
@@ -28,7 +28,7 @@ class Locator extends Component<ILocatorProps, ILocatorState> {
         // Don't call this.setState() here!
         this.state = {
             finishedInput: false,
-            currentStage: 0,
+            currentStage: 1,
         };
 
         this.markers = [];
@@ -43,7 +43,7 @@ class Locator extends Component<ILocatorProps, ILocatorState> {
     }
 
     public resetButtonClicked() {
-        this.markers = [];
+        this.markers.length = 0;
         this.setState({ currentStage: 1, finishedInput: false });
     }
 

--- a/react/src/Components/Canvases/BaseCanvas.tsx
+++ b/react/src/Components/Canvases/BaseCanvas.tsx
@@ -125,18 +125,18 @@ class BaseCanvas extends Component<IBaseCanvasProps, IBaseCanvasState> {
     }
 
     public handleStart(evt: any) {
-        this.draw();
         this.props.handleStartCB(evt);
+        this.draw();
     }
 
     public handleMove(evt: any) {
-        this.draw();
         this.props.handleMoveCB(evt);
+        this.draw();
     }
 
     public handleEnd(evt: any) {
-        this.draw();
         this.props.handleEndCB(evt);
+        this.draw();
     }
 
     public updateCanvasDims() {

--- a/react/src/Components/Canvases/BoundingBoxCreationCanvas.tsx
+++ b/react/src/Components/Canvases/BoundingBoxCreationCanvas.tsx
@@ -219,7 +219,7 @@ class BoundingBoxCreationCanvas extends Component<IBoundingBoxCreationCanvasProp
         drawActiveImageOverlay(ctx, rect, canvasRect, this.image);
         this.drawHelperLines(ctx, canvasRect);
 
-        if (this.props.targetPoint && this.props.targetPoint !== null) {
+        if (this.props.targetPoint && this.props.targetPoint !== null && this.props.targetPoint.x !== null) {
             drawMarker(ctx, this.props.targetPoint, this.imageBounds);
         }
     }


### PR DESCRIPTION
errors include:
* type errors in the generators
* front end integration with backend errors
* the wrong kinds of tasks being served as activitites (since dichotomy tasks have state machines too oops)
* test fixes due to migration
* javascript syntax errors
* javascript draw errors

still not done debugging the full state machine yet, but here's a good chunk to at least get things rolling