### PR TITLE
rails: fix internal tooling tag samples route

### DIFF
--- a/rails/app/controllers/v1/tags_controller.rb
+++ b/rails/app/controllers/v1/tags_controller.rb
@@ -67,7 +67,6 @@ class V1::TagsController < ApplicationController
 
   def base_tag_params(task)
     type = task.actable_type
-    task = task.specific
     media = Medium.find(task.media_id)
     { type: type, task: task, media: media }
   end


### PR DESCRIPTION
made an oopsie where it was rendering the specific task id instead of the base task id