### PR TITLE
rails: fix threshold bug

### DIFF
--- a/rails/app/models/generators/bounding_box_generator.rb
+++ b/rails/app/models/generators/bounding_box_generator.rb
@@ -4,9 +4,9 @@
 class BoundingBoxGenerator
   def self.generate_tag(task)
     samples = BoundingBoxSample.where(task_id: task.id).order(created_at: :DESC)
-    delta = 0.03
+    threshold = 0.03 * (samples.count - 1)
     comparison_func = ->(s1, s2, d) { compare_bounding_boxes(s1, s2, d) }
-    sample_pair = ComparisonUtils.sample_pair_exists(samples, comparison_func, delta)
+    sample_pair = ComparisonUtils.sample_pair_exists(samples, comparison_func, threshold)
 
     return BasicTaskEvent.create(task_id: task.id, event: 'dissimilar') unless sample_pair
 

--- a/rails/app/models/generators/locator_generator.rb
+++ b/rails/app/models/generators/locator_generator.rb
@@ -4,7 +4,7 @@
 class LocatorGenerator
   def self.generate_tag(task)
     samples = LocatorSample.where(task_id: task.id).order(created_at: :DESC)
-    threshold = 0.03
+    threshold = 0.03 * (samples.count - 1)
     comparison_func = ->(s1, s2, t) { compare_points_lists(s1, s2, t) }
     sample_pair = ComparisonUtils.sample_pair_exists(samples, comparison_func, threshold)
 

--- a/rails/app/models/utils/comparison_utils.rb
+++ b/rails/app/models/utils/comparison_utils.rb
@@ -2,8 +2,7 @@
 
 # Comparison utilities.
 class ComparisonUtils
-  def self.sample_pair_exists(samples, comparison_func, delta)
-    threshold = delta * (samples.count - 1)
+  def self.sample_pair_exists(samples, comparison_func, threshold)
     samples.each_with_index do |sample1, i1|
       samples[i1 + 1..-1].each do |sample2|
         return [sample1, sample2] if comparison_func.call(sample1, sample2, threshold)


### PR DESCRIPTION
we were dropping locator points because the threshold used by the comparison function was not the same as the threshold used by the generation function. This is because we were silently modifying (defaulting) the threshold in the ComparisonUtil.

This bug did not affect the bounding box generator, but I'm plumbing it through to stay consistent

This change dumbs down the ComparisonUtils and forces the generator to define the threshold.