### PR TITLE
react: increase target contrast

### DIFF
--- a/react/src/Components/Canvases/CanvasDrawUtils.tsx
+++ b/react/src/Components/Canvases/CanvasDrawUtils.tsx
@@ -10,17 +10,11 @@ function drawMarker(ctx: CanvasRenderingContext2D, marker: IPoint, imageBounds: 
     const radius = Math.max(imageBounds.w, imageBounds.h) / 60;
     const x = marker.x * imageBounds.w + imageBounds.x;
     const y = marker.y * imageBounds.h + imageBounds.y;
-    // Draw black outer circle
-    ctx.beginPath();
-    ctx.strokeStyle = "#000000";
-    ctx.ellipse(
-        x, y,
-        radius, radius, 0, 0, Math.PI * 2);
-    ctx.stroke();
 
-    // Draw white inner circle
+    // Draw green circle
     ctx.beginPath();
-    ctx.strokeStyle = "#FFFFFF";
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = "#00FF00";
     ctx.ellipse(
         x, y,
         radius + 1, radius + 1, 0, 0, Math.PI * 2);
@@ -42,6 +36,7 @@ function drawMarker(ctx: CanvasRenderingContext2D, marker: IPoint, imageBounds: 
 
     ctx.restore();
 }
+
 function drawGreenMarker(ctx: CanvasRenderingContext2D, marker: IPoint, imageBounds: IRect) {
     if (ctx === null) {
         return;


### PR DESCRIPTION
<img width="1058" alt="Screen Shot 2020-03-21 at 3 55 44 PM" src="https://user-images.githubusercontent.com/5915070/77235505-905f9c80-6b8c-11ea-8ca0-e613a57442eb.png">

i couldn't see some of the markers immediately, was kind frustrating
ill update the helper images at some point