### PR TITLE
react: fix diff view errors

### DIFF
--- a/react/src/Components/UIElements/TagDiffPreview.tsx
+++ b/react/src/Components/UIElements/TagDiffPreview.tsx
@@ -69,6 +69,9 @@ class TagDiffPreview extends Component<any, any> {
     public dichotomyMatchAttributesPreview(metadata0: any, metadata1: any) {
         return metadata1.attributes.map((t: any) => {
             const baseAttr = metadata0.attributes.find((element: any) => element.attribute_type === t.attribute_type);
+            if (!baseAttr) {
+                return null;
+            }
             const matches: boolean = baseAttr.option === t.option;
             return <div key={t.attribute_type} style={{ backgroundColor: matches ? "green" : "red" }}>
                 {t.attribute_type}-{t.option} ({matches ? "DA_C" : "DA_I"})
@@ -102,7 +105,7 @@ class TagDiffPreview extends Component<any, any> {
     }
 
     public withinDelta(bb0: IBoundingBox, bb1: IBoundingBox): boolean {
-        const delta = 0.05;
+        const delta = 0.06;
         return Math.abs(bb0.min_x - bb1.min_x) < delta
             && Math.abs(bb0.min_y - bb1.min_y) < delta
             && Math.abs(bb0.max_x - bb1.max_x) < delta

--- a/react/src/Components/Views/TagDiffView.tsx
+++ b/react/src/Components/Views/TagDiffView.tsx
@@ -79,22 +79,22 @@ class SamplesView extends Component<any, any> {
             if (tag0 === null && tag1 === null) {
                 break;
             }
-
+            const key = "" + idx0 + "_" + idx1;
             if (tag0 && tag1 && tag0.media.name === tag1.media.name) {
-                tagDiffs.push(<TagDiffPreview key={tag0.media.name} tag0={tag0} tag1={tag1}></TagDiffPreview>);
+                tagDiffs.push(<TagDiffPreview key={key} tag0={tag0} tag1={tag1}></TagDiffPreview>);
                 idx0 += 1;
                 idx1 += 1;
                 continue;
             }
 
             if ((tag0 && tag1 && tag0.media.name < tag1.media.name) || tag1 === null) {
-                tagDiffs.push(<TagDiffPreview key={tag0.media.name} tag0={tag0} tag1={null}></TagDiffPreview>);
+                tagDiffs.push(<TagDiffPreview key={key} tag0={tag0} tag1={null}></TagDiffPreview>);
                 idx0 += 1;
                 continue;
             }
 
             if ((tag0 && tag1 && tag0.media.name > tag1.media.name) || tag0 === null) {
-                tagDiffs.push(<TagDiffPreview key={tag1.media.name} tag0={null} tag1={tag1}></TagDiffPreview>);
+                tagDiffs.push(<TagDiffPreview key={key} tag0={null} tag1={tag1}></TagDiffPreview>);
                 idx1 += 1;
                 continue;
             }


### PR DESCRIPTION
basically prevent this problem:

<img width="1072" alt="Screen Shot 2020-03-21 at 8 06 49 PM" src="https://user-images.githubusercontent.com/5915070/77239295-89965100-6baf-11ea-90d3-be1f65cecaf2.png">

might have to up the threshold, who knows. should probably make the threshold programatic, but w/e