### PR TITLE
fullstack: add ordering parameter to tags endpoint to fix diff view

### DIFF
--- a/rails/app/controllers/v1/tags_controller.rb
+++ b/rails/app/controllers/v1/tags_controller.rb
@@ -33,10 +33,16 @@ class V1::TagsController < ApplicationController
     params[:limit] ? params[:limit].to_i : 10
   end
 
+  def tag_sort
+    return Medium.arel_table[:name].asc if params[:sort] && params[:sort] == "media_name"
+    Task.arel_table[:created_at].asc
+  end
+
   def tags_for(project_id, timestamp)
     Task.joins(:sample)
+      .joins("INNER JOIN media ON media.id = tasks.media_id")
       .where(tags_filter, project_id)
-      .order(created_at: :asc)
+      .order(tag_sort)
       .where(Sample.arel_table[:created_at].lt(timestamp))
       .offset(pagination_offset)
       .limit(pagination_limit)

--- a/react/src/Components/Views/TagDiffView.tsx
+++ b/react/src/Components/Views/TagDiffView.tsx
@@ -37,7 +37,11 @@ class SamplesView extends Component<any, any> {
 
     public async loadTags(idx: number) {
         const projectId = this.state.projectIds[idx];
-        const meta = { offset: this.state.tagOffsets[idx], timestamp: this.state.tagTimestamps[idx] };
+        const meta = {
+            offset: this.state.tagOffsets[idx],
+            timestamp: this.state.tagTimestamps[idx],
+            sort: "media_name",
+        };
         return await Backend.getTags(projectId, meta);
     }
 


### PR DESCRIPTION
some of tasks end up being out of order, and the diff view assumes the media name is in sorted order. It only happened to work before by pure chance that the tasks were 1:1. 